### PR TITLE
Fix syntax errors and README.md file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ The script have two modes of operation:
 3. Run the script with the date of the last successful upgrade as an argument. For example, if the last successful upgrade was on the 27th of May 2024, you would run the script as follows:
 ```bash
 # Check first what packages will be reinstalled using the --dry-run option
-archlinux-pkgrecover.sh --pacman-db/--paclog "2024-05-27" [--no-db] --dry-run
+./pkgrecover.sh --pacman-db/--paclog "2024-05-27" [--no-db] --dry-run
 
 # If you are happy with the list of packages that will be reinstalled
-archlinux-pkgrecover.sh --pacman-db/--paclog "2024-05-27" [--no-db]
+./pkgrecover.sh --pacman-db/--paclog "2024-05-27" [--no-db]
 ```
 
 # Examples
@@ -45,28 +45,28 @@ archlinux-pkgrecover.sh --pacman-db/--paclog "2024-05-27" [--no-db]
 1. Using the pacman log file among with the pacman database:
 ```bash
 # Check first what packages will be reinstalled using the --dry-run option
-archlinux-pkgrecover.sh --paclog "2024-05-27" --dry-run
+./pkgrecover.sh --paclog "2024-05-27" --dry-run
 
 # If you are happy with the list of packages that will be reinstalled
-archlinux-pkgrecover.sh --paclog "2024-05-27"
+./pkgrecover.sh --paclog "2024-05-27"
 ```
 
 2. Using the pacman log file without the pacman database:
 ```bash
 # Check first what packages will be reinstalled using the --dry-run option
-archlinux-pkgrecover.sh --paclog "2024-05-27" --no-db --dry-run
+./pkgrecover.sh --paclog "2024-05-27" --no-db --dry-run
 
 # If you are happy with the list of packages that will be reinstalled
-archlinux-pkgrecover.sh --paclog "2024-05-27" --no-db
+./pkgrecover.sh --paclog "2024-05-27" --no-db
 ```
 
 3. Using the package database:
 ```bash
 # Check first what packages will be reinstalled using the --dry-run option
-archlinux-pkgrecover.sh --pacman-db "2024-05-27" --dry-run
+./pkgrecover.sh --pacman-db "2024-05-27" --dry-run
 
 # If you are happy with the list of packages that will be reinstalled
-archlinux-pkgrecover.sh --pacman-db "2024-05-27"
+./pkgrecover.sh --pacman-db "2024-05-27"
 ```
 
 # License

--- a/pkgrecover.sh
+++ b/pkgrecover.sh
@@ -7,17 +7,17 @@ YELLOW='\033[1;33m'
 
 directory_check() {
     #checks to make sure that all the important directories are mounted properly
-    if [[ ! -d /proc]]; then
+    if [[ ! -d /proc ]]; then
         echo -e "${RED} ERROR: /proc is not mounted. upgrading without /proc mounted can cause damage."
         exit 1
     fi
-    
-    if [[ ! -d /sys]]; then
+
+    if [[ ! -d /sys ]]; then
         echo -e "${RED} ERROR: /sys is not mounted. upgrading without /sys mounted can cause damage."
         exit 1
     fi
 
-    if [[ ! -d /boot]]; then
+    if [[ ! -d /boot ]]; then
         echo -e "${RED} ERROR: /boot is not mounted. upgrading without /boot mounted can cause damage."
         exit 1
     fi


### PR DESCRIPTION
Hi. This script was very useful for me to recover from a partial update. However, I found some syntax errors, specifically missing spaces before closing double brackets in if-statements, like in: `if [[ ! -d /proc]]; then`. I fixed these and the script ran flawlessly. While doing so, I also updated the path file name in the README.md, which was still pointing to `archlinux-pkgrecover.sh` instead of `pkgrecover.sh`. Cheers!